### PR TITLE
Ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
During the folder restructuring the .gitignore file got moved to client. This just adds a root level gitignore to ignore the dependency folder.